### PR TITLE
add pre and post display hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ popup with all Markdown translated and using the correct GitHub styling.
 
 - [Installation](#installation)
 - [How to use](#how-to-use)
-- [Test Web app](#test-web-app)
-  - [Test app Limitations](#test-app-limitations)
+  - [Pre / Post Hooks](#pre--post-hooks)
+- [Example Web app](#example-web-app)
+  - [Example app Limitations](#example-app-limitations)
 - [Contributing](#contributing)
   - [Using the test Application](#using-the-test-application)
   - [Hacking on the component](#hacking-on-the-component)
@@ -59,17 +60,26 @@ import { GitHubReadmeButton } from react-github-readme-button
   fileName="README.md" // optional, defaults to 'README.md'
   className="button-style" // optional but recommended, style the button
   buttonText = "View README" // Button text, optional, defaults to 'View README'
+  preDisplayHook={handlePreDisplayHook} // See below
+  postDisplayHook={handlePostDisplayHook} // See below
 />
 ```
 
-## Test Web app
+### Pre / Post Hooks
 
-A test app is available at
+The 2 hooks `preDisplayHook` and `postDisplayHook` are called just before the
+README is rendered and just after it is removed respectively. These were
+primarily designed to pause timers used in a Carousel system but can do any
+processing you need. See the Example Web app for a usage example.
+
+## Example Web app
+
+An example app is available at
 <https://seapagan.github.io/react-github-readme-button/> or from a local clone
 of the repository on <http://localhost:3000>. This uses the  local code of the
 component, so is good to use during development.
 
-### Test app Limitations
+### Example app Limitations
 
 - only fetches README.md
 - only fetches from the `main` branch.

--- a/src/App.js
+++ b/src/App.js
@@ -19,6 +19,14 @@ function App() {
     setSearchRepo(repoName.toLowerCase());
   };
 
+  const handlePreDisplayHook = e => {
+    console.log("Pre-display Hook Fired!!");
+  };
+
+  const handlePostDisplayHook = e => {
+    console.log("Post-display Hook Fired!!");
+  };
+
   return (
     <div className="app">
       <form autoComplete="off">
@@ -45,8 +53,13 @@ function App() {
       </p>
       <div className="click-message">
         Click this to{" "}
-        <GitHubReadmeButton className="button-style" repo={searchRepo} /> (ESC
-        Closes the popup)
+        <GitHubReadmeButton
+          className="button-style"
+          repo={searchRepo}
+          preDisplayHook={handlePreDisplayHook}
+          postDisplayHook={handlePostDisplayHook}
+        />{" "}
+        (ESC Closes the popup)
       </div>
     </div>
   );

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,0 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/src/components/GitHubReadmeButton/GitHubReadmeButton.js
+++ b/src/components/GitHubReadmeButton/GitHubReadmeButton.js
@@ -14,6 +14,7 @@ export const GitHubReadmeButton = ({
   const [isVisible, setIsVisible] = useState(false);
 
   const showReadme = () => {
+    otherProps.preDisplayHook && otherProps.preDisplayHook();
     setIsVisible(true);
   };
 
@@ -22,12 +23,14 @@ export const GitHubReadmeButton = ({
   // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md
   function closeHandler() {
     setIsVisible(false);
+    otherProps.postDisplayHook && otherProps.postDisplayHook();
   }
 
   useEffect(() => {
     const handleEsc = e => {
       if (e.keyCode === 27) {
         setIsVisible(false);
+        otherProps.postDisplayHook && otherProps.postDisplayHook();
       }
     };
     window.addEventListener("keydown", handleEsc);
@@ -35,7 +38,7 @@ export const GitHubReadmeButton = ({
     return () => {
       window.removeEventListener("keydown", handleEsc);
     };
-  }, []);
+  }, [otherProps]);
 
   return (
     <>


### PR DESCRIPTION
These hooks are called before the README is displayed and after it is hidden. The original idea was so that a carousel could be paused while the README is displayed, and then resumed at the same place when the README is closed.